### PR TITLE
Present label error in UI.

### DIFF
--- a/app/assets/javascripts/spree/backend/package_type_selector.js.coffee
+++ b/app/assets/javascripts/spree/backend/package_type_selector.js.coffee
@@ -11,9 +11,13 @@ $(document).on 'change', selector, ->
   insurace = null if insurance == ''
 
   $.post resource, package_type_id: package_type_id, insurance: insurance
-    .fail ->
+    .fail (transport)->
       $_.val $_.attr('data-last-value')
-      alert 'Failed to generate label for selected package.'
+      msg = if transport.responseJSON
+        transport.responseJSON.exception
+      else
+        'Failed to generate label for selected package.'
+      alert msg
     .done (label)->
       last_value = $_.attr 'data-last-value'
       $_.find("option[value='']").remove()

--- a/app/controllers/spree/admin/labels_controller.rb
+++ b/app/controllers/spree/admin/labels_controller.rb
@@ -32,10 +32,13 @@ class Spree::Admin::LabelsController < Spree::Admin::BaseController
       shipment.insurance_enabled = false
     end
 
-    shipment.generate_label! if
-      shipment.package_type_id_changed? || shipment.insurance_changed? || shipment.insurance_enabled_changed?
-
-    render json: shipment.label, only: %i(cost)
+    begin
+      shipment.generate_label! if
+        shipment.package_type_id_changed? || shipment.insurance_changed? || shipment.insurance_enabled_changed?
+      render json: shipment.label, only: %i(cost)
+    rescue Spree::ShippingLabels::Error
+      render json: { exception: $!.message }, status: :unprocessable_entity
+    end
   end
 
 end

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -28,9 +28,13 @@ Spree::Shipment.class_eval do
   def generate_label!
     raise Spree::ShippingLabels::Error, 'Cannot generate a label without a package type' unless package_type
     raise Spree::ShippingLabels::Error, 'Cannot generate a label without a label-able selected shipping method' unless calculator
-    # Restrict to just 5 seconds to get response to avoid appearing slow
-    timeout 10 do
-      package_type.provider.generate_label! calculator.preferred_service_type, package_type, self
+    begin
+      # Restrict to just 5 seconds to get response to avoid appearing slow
+      timeout 10 do
+        package_type.provider.generate_label! calculator.preferred_service_type, package_type, self
+      end
+    rescue # Unfortuantly the shipping companies throw a fairily generic error.
+      raise Spree::ShippingLabels::Error, $!.message
     end
   end
 


### PR DESCRIPTION
Previously we just had a generic error regardless of the cause. I didn't
think it would be a common occurance so I just `!` it and let it bubble up
as a 500 error.

In reality labels fail to generate for a variety of reasons. Some may be due
to infrasturcture reasons (invalid key, networking issues, etc) while others
may be due to transactional reasons (not enough money in provide account,
invalid address).

By bubbling up the true error we let the user correct those transactional issues
themselves reducing support on our side and letting them correct the issue
more timely. Even when it is infrastructural if we get a screenshot then we will
have better information to start with and not have to dig through the logs.
